### PR TITLE
Resize images to fit box

### DIFF
--- a/css/p3.css
+++ b/css/p3.css
@@ -13,6 +13,7 @@ body {
 	cursor:pointer; 
 	margin-right:5px;
 	margin-bottom:5px;
+	background-size: cover;
 }
 
 #timer{


### PR DESCRIPTION
Currently, image is partially clipped by box's size as shown below. If the image has large white margin area, there can be only white box displayed. 
![image_can_be_displayed_as_blank](https://f.cloud.github.com/assets/2943548/1846213/4e5112ee-75d2-11e3-80e7-73ad904e9d6c.png)

This PR add a single line css for resizing image to fit box's size.
